### PR TITLE
Implement simple scoring and portfolio script

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,15 @@
 - **Performance:** Clear benchmark comparison with SPY
 - **Technical:** Sub-2 second execution, > 95% data quality
 - **Professional:** Interview-ready documentation and presentation
+
+## Quickstart
+
+After running the ETF pipeline you can build a tiny demo portfolio using the new script:
+
+```bash
+python -m scripts.portfolio
+```
+
+This reads `data/processed/etf_master.csv`, ranks tickers by a Sharpe/Momentum composite and prints equal weights for the top names.
+
+To validate the scoring utilities run the test suite with `pytest`.

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -1,0 +1,46 @@
+"""Simple portfolio construction using processed ETF data."""
+import csv
+from pathlib import Path
+from typing import Dict, List
+
+from .scoring import compute_sharpe, lagged_momentum
+
+BASE = Path(__file__).parent.parent
+
+def load_prices(path: Path) -> Dict[str, List[float]]:
+    """Load close prices from processed CSV grouped by ticker."""
+    data: Dict[str, List[float]] = {}
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            t = row["ticker"].upper()
+            data.setdefault(t, []).append(float(row["Close"]))
+    return data
+
+def score_tickers(price_hist: Dict[str, List[float]]) -> Dict[str, float]:
+    scores = {}
+    for ticker, prices in price_hist.items():
+        returns = [ (p2/p1) - 1 for p1, p2 in zip(prices[:-1], prices[1:]) ]
+        sharpe = compute_sharpe(returns)
+        try:
+            mom = lagged_momentum(prices)
+        except ValueError:
+            mom = 0.0
+        composite = 0.6 * sharpe + 0.4 * mom
+        scores[ticker] = composite
+    return scores
+
+def build_portfolio(n: int = 5) -> Dict[str, float]:
+    data_path = BASE / "data" / "processed" / "etf_master.csv"
+    price_hist = load_prices(data_path)
+    scores = score_tickers(price_hist)
+    top = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)[:n]
+    if not top:
+        return {}
+    weight = 1 / len(top)
+    return {t: weight for t, _ in top}
+
+if __name__ == "__main__":
+    pf = build_portfolio()
+    for t, w in pf.items():
+        print(f"{t}: {w:.2%}")

--- a/scripts/scoring.py
+++ b/scripts/scoring.py
@@ -1,0 +1,32 @@
+"""Scoring utilities for ETFs and stocks.
+
+These functions avoid heavy dependencies so that tests
+run in minimal environments.
+"""
+import math
+import statistics as st
+from typing import List
+
+def compute_sharpe(returns: List[float], risk_free: float = 0.0) -> float:
+    """Compute annualized Sharpe ratio given daily returns."""
+    if not returns:
+        return 0.0
+    excess = [r - risk_free/252 for r in returns]
+    avg = st.mean(excess)
+    std = st.stdev(excess) if len(excess) > 1 else 0
+    if std == 0:
+        return 0.0
+    return math.sqrt(252) * avg / std
+
+def lagged_momentum(prices: List[float], months: int = 6, lag: int = 1, period: int = 21) -> float:
+    """Return percentage change over ``months`` ending ``lag`` months ago."""
+    needed = (months + lag) * period
+    if len(prices) < needed:
+        raise ValueError("Not enough price history for momentum calculation")
+    end_idx = len(prices) - lag * period - 1
+    start_idx = len(prices) - (months + lag) * period - 1
+    start = prices[start_idx]
+    end = prices[end_idx]
+    if start == 0:
+        return 0.0
+    return end / start - 1

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from scripts.portfolio import load_prices, score_tickers
+from pathlib import Path
+
+
+def test_load_prices(tmp_path):
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text("Date,Close,ticker\n2021-01-01,100,A\n2021-01-02,101,A\n")
+    data = load_prices(csv_path)
+    assert data == {"A": [100.0, 101.0]}
+
+
+def test_score_tickers():
+    hist = {"A": [100 + i for i in range(300)]}
+    scores = score_tickers(hist)
+    assert "A" in scores

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,15 @@
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from scripts.scoring import compute_sharpe, lagged_momentum
+
+def test_compute_sharpe_nonzero():
+    returns = [0.01, 0.02] * 126
+    sr = compute_sharpe(returns)
+    assert sr > 40
+
+def test_lagged_momentum():
+    prices = list(range(500))
+    m = lagged_momentum(prices, months=6, lag=1)
+    assert round(m, 6) == round(0.3579545454545454, 6)


### PR DESCRIPTION
## Summary
- add utilities to compute sharpe ratio and momentum without heavy deps
- build lightweight portfolio constructor that ranks ETFs using these scores
- document quick usage instructions in README
- add unit tests for scoring and portfolio helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b09bb11483328b8c7dea83f2269b