### PR TITLE
Add settings config and pin dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,12 @@ python -m scripts.portfolio
 This reads `data/processed/etf_master.csv`, ranks tickers by a Sharpe/Momentum composite and prints equal weights for the top names.
 
 To validate the scoring utilities run the test suite with `pytest`.
+
+### Configuration
+
+Key parameters like lookback windows and score weights live in `config/settings.yml`.
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```

--- a/config/etf_list.yml
+++ b/config/etf_list.yml
@@ -1,0 +1,10 @@
+- VOO
+- SPY
+- QQQ
+- IWM
+- EFA
+- EEM
+- VNQ
+- AGG
+- LQD
+- GLD

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,10 @@
+lookback_months: 12
+vol_thresh: 100000
+score_weights:
+  sharpe: 0.6
+  momentum: 0.4
+screener:
+  min_aum: 15000000000
+  min_avg_vol: 1000000
+  must_include:
+    - VOO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+yfinance==0.2.18
+pandas==1.5.3
+numpy==1.24.3
+pyyaml==6.0

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1,13 +1,18 @@
 # scripts/pipeline.py
 
-from .utils      import load_etf_list, data_paths
+from .utils      import load_etf_list, data_paths, load_settings, validate_tickers
 from .ingestion  import fetch_etf_data, build_price_df
 from .cleaning   import filter_min_history, fill_missing, flag_illiquid
 from .tagging    import assign_broad_category, assign_detailed_sector
 
-def run_etf_pipeline(months=12, vol_thresh=1e5):
+def run_etf_pipeline(months=None, vol_thresh=None):
+    cfg = load_settings()
+    if months is None:
+        months = cfg.get("lookback_months", 12)
+    if vol_thresh is None:
+        vol_thresh = cfg.get("vol_thresh", 1e5)
     # 1) Universe
-    etfs = load_etf_list()
+    etfs = validate_tickers(load_etf_list())
 
     # 2) Ingest
     raw      = fetch_etf_data(etfs)

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from .scoring import compute_sharpe, lagged_momentum
+from .utils import load_settings
 
 BASE = Path(__file__).parent.parent
 
@@ -18,6 +19,9 @@ def load_prices(path: Path) -> Dict[str, List[float]]:
     return data
 
 def score_tickers(price_hist: Dict[str, List[float]]) -> Dict[str, float]:
+    cfg = load_settings().get("score_weights", {"sharpe": 0.6, "momentum": 0.4})
+    w_sharpe = cfg.get("sharpe", 0.6)
+    w_mom = cfg.get("momentum", 0.4)
     scores = {}
     for ticker, prices in price_hist.items():
         returns = [ (p2/p1) - 1 for p1, p2 in zip(prices[:-1], prices[1:]) ]
@@ -26,7 +30,7 @@ def score_tickers(price_hist: Dict[str, List[float]]) -> Dict[str, float]:
             mom = lagged_momentum(prices)
         except ValueError:
             mom = 0.0
-        composite = 0.6 * sharpe + 0.4 * mom
+        composite = w_sharpe * sharpe + w_mom * mom
         scores[ticker] = composite
     return scores
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,11 +1,35 @@
 # scripts/utils.py
 
-import pandas as pd
+try:
+    import pandas as pd
+except Exception:  # pragma: no cover - optional dependency
+    pd = None
 from pathlib import Path
-import yaml
+try:
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+try:
+    import yfinance as yf
+except Exception:  # pragma: no cover - optional dependency
+    yf = None
 
 # BASE → the root of your “Portfolio Model” project
 BASE = Path(__file__).parent.parent
+
+_SETTINGS = None
+
+def load_settings() -> dict:
+    """Read config/settings.yml once and cache the result."""
+    global _SETTINGS
+    if _SETTINGS is None:
+        path = BASE / "config" / "settings.yml"
+        if path.exists() and yaml is not None:
+            _SETTINGS = yaml.safe_load(path.read_text()) or {}
+        else:
+            _SETTINGS = {}
+    return _SETTINGS
 
 def data_paths() -> dict:
     """
@@ -17,20 +41,31 @@ def data_paths() -> dict:
     }
 
 def load_etf_list() -> list[str]:
-    """
-    Returns your ETF universe by running the screener stub.
-    """
-    from .screener import screen_etfs
-    return screen_etfs(
-        min_aum=15e9,
-        min_avg_vol=1e6,
-        must_include=["VOO"]
-    )
+    """Return the ETF universe from etf_list.yml or via the screener stub."""
+    cfg = load_settings().get("screener", {})
+
+    path = BASE / "config" / "etf_list.yml"
+    tickers = []
+    if path.exists() and yaml is not None:
+        raw = yaml.safe_load(path.read_text()) or []
+        tickers = [str(t).upper() for t in raw if t]
+
+    if not tickers:
+        from .screener import screen_etfs
+        tickers = screen_etfs(
+            min_aum=cfg.get("min_aum", 15e9),
+            min_avg_vol=cfg.get("min_avg_vol", 1e6),
+            must_include=cfg.get("must_include", ["VOO"]),
+        )
+
+    return sorted(set(tickers))
 
 def load_sector_map() -> dict:
     """
     Reads config/sector_map.csv into a { ticker: detailed_sector } dict.
     """
+    if pd is None:
+        raise ImportError("pandas is required for load_sector_map")
     path = BASE / "config" / "sector_map.csv"
     df   = pd.read_csv(path, index_col="ticker")
     return df["detailed_sector"].to_dict()
@@ -40,4 +75,21 @@ def load_yaml_config(name: str) -> dict:
     Helper to read any YAML under config/, e.g. etf_list.yml.
     """
     path = BASE / "config" / name
+    if yaml is None:
+        raise ImportError("pyyaml is required for load_yaml_config")
     return yaml.safe_load(path.read_text())
+
+
+def validate_tickers(tickers: list[str]) -> list[str]:
+    """Simple validation to drop tickers with no available data."""
+    if yf is None:
+        return tickers
+    valid = []
+    for t in tickers:
+        try:
+            data = yf.Ticker(t).history(period="1d")
+            if not data.empty and data.iloc[-1]["Close"] > 0:
+                valid.append(t)
+        except Exception:
+            continue
+    return valid


### PR DESCRIPTION
## Summary
- pin key Python packages in requirements.txt
- centralize configurable values in `config/settings.yml`
- update utilities and portfolio logic to read settings
- validate tickers before ingestion
- document config usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4b1cc50083328a09a3204e7fd743