### PR TITLE
Add volatility factor and diversification

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@
 
 ## Quickstart
 
-After running the ETF pipeline you can build a tiny demo portfolio using the new script:
+After running the ETF pipeline you can build a diversified example portfolio using the new script:
 
 ```bash
 python -m scripts.portfolio
 ```
 
-This reads `data/processed/etf_master.csv`, ranks tickers by a Sharpe/Momentum composite and prints equal weights for the top names.
+This reads `data/processed/etf_master.csv`, scores tickers using Sharpe ratio, momentum and volatility, and ensures at least one ETF from each major asset class. It then prints equal weights for the selected names.
 
 To validate the scoring utilities run the test suite with `pytest`.
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,8 +1,9 @@
 lookback_months: 12
 vol_thresh: 100000
 score_weights:
-  sharpe: 0.6
-  momentum: 0.4
+  sharpe: 0.5
+  momentum: 0.3
+  volatility: 0.2
 screener:
   min_aum: 15000000000
   min_avg_vol: 1000000

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -1,9 +1,9 @@
 """Simple portfolio construction using processed ETF data."""
 import csv
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
-from .scoring import compute_sharpe, lagged_momentum
+from .scoring import compute_sharpe, lagged_momentum, compute_volatility
 from .utils import load_settings
 
 BASE = Path(__file__).parent.parent
@@ -18,31 +18,72 @@ def load_prices(path: Path) -> Dict[str, List[float]]:
             data.setdefault(t, []).append(float(row["Close"]))
     return data
 
+def load_prices_and_meta(path: Path) -> Tuple[Dict[str, List[float]], Dict[str, str]]:
+    """Return price history and broad category for each ticker."""
+    prices: Dict[str, List[float]] = {}
+    cats: Dict[str, str] = {}
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            t = row["ticker"].upper()
+            prices.setdefault(t, []).append(float(row["Close"]))
+            cats[t] = row.get("broad_cat", "Unknown")
+    return prices, cats
+
 def score_tickers(price_hist: Dict[str, List[float]]) -> Dict[str, float]:
-    cfg = load_settings().get("score_weights", {"sharpe": 0.6, "momentum": 0.4})
-    w_sharpe = cfg.get("sharpe", 0.6)
-    w_mom = cfg.get("momentum", 0.4)
+    """Compute composite scores using Sharpe, Momentum and Volatility."""
+    cfg = load_settings().get(
+        "score_weights",
+        {"sharpe": 0.5, "momentum": 0.3, "volatility": 0.2},
+    )
+    w_sharpe = cfg.get("sharpe", 0.5)
+    w_mom = cfg.get("momentum", 0.3)
+    w_vol = cfg.get("volatility", 0.2)
+
     scores = {}
     for ticker, prices in price_hist.items():
-        returns = [ (p2/p1) - 1 for p1, p2 in zip(prices[:-1], prices[1:]) ]
+        returns = [(p2 / p1) - 1 for p1, p2 in zip(prices[:-1], prices[1:])]
         sharpe = compute_sharpe(returns)
+        vol = compute_volatility(returns)
         try:
             mom = lagged_momentum(prices)
         except ValueError:
             mom = 0.0
-        composite = w_sharpe * sharpe + w_mom * mom
+        # lower volatility is better so invert the ranking sign
+        composite = w_sharpe * sharpe + w_mom * mom - w_vol * vol
         scores[ticker] = composite
     return scores
 
 def build_portfolio(n: int = 5) -> Dict[str, float]:
+    """Select top ``n`` tickers ensuring category diversification."""
     data_path = BASE / "data" / "processed" / "etf_master.csv"
-    price_hist = load_prices(data_path)
+    price_hist, cats = load_prices_and_meta(data_path)
+
     scores = score_tickers(price_hist)
-    top = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)[:n]
-    if not top:
+    ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+
+    required_cats = {"Equity", "Fixed Income", "Commodity", "Real Estate"}
+    selected: Dict[str, str] = {}
+
+    # First pass: ensure one per category if available
+    for ticker, _ in ranked:
+        cat = cats.get(ticker, "Other")
+        if cat in required_cats and cat not in selected:
+            selected[ticker] = cat
+        if len(selected) == len(required_cats) or len(selected) == n:
+            break
+
+    # Fill remaining slots with best remaining tickers
+    for ticker, _ in ranked:
+        if len(selected) >= n:
+            break
+        if ticker not in selected:
+            selected[ticker] = cats.get(ticker, "Other")
+
+    if not selected:
         return {}
-    weight = 1 / len(top)
-    return {t: weight for t, _ in top}
+    weight = 1 / len(selected)
+    return {t: weight for t in selected}
 
 if __name__ == "__main__":
     pf = build_portfolio()

--- a/scripts/scoring.py
+++ b/scripts/scoring.py
@@ -30,3 +30,11 @@ def lagged_momentum(prices: List[float], months: int = 6, lag: int = 1, period: 
     if start == 0:
         return 0.0
     return end / start - 1
+
+def compute_volatility(returns: List[float]) -> float:
+    """Annualized standard deviation of daily returns."""
+    if not returns:
+        return 0.0
+    std = st.stdev(returns) if len(returns) > 1 else 0
+    return math.sqrt(252) * std
+


### PR DESCRIPTION
## Summary
- extend scoring utils with volatility calculation
- diversify selection by broad category
- support new weight settings for volatility factor
- update README quickstart description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4e9d5efc83328c850a9a81bd4aa1